### PR TITLE
Update the name of the Typed Link Field plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Hyper is a Craft CMS field for creating links, with a focus on user experience a
 - Plenty of template helpers to make rendering links a breeze and extensible.
 - GraphQL support for querying links.
 - Feed Me support for importing links in elements like entries.
-- One-click migrations for [Typed Link](https://github.com/sebastian-lenz/craft-linkfield), [Linkit](https://github.com/presseddigital/linkit) and [Link](https://github.com/flipboxfactory/craft-link) fields.
+- One-click migrations for [Typed Link Field](https://github.com/sebastian-lenz/craft-linkfield), [Linkit](https://github.com/presseddigital/linkit) and [Link](https://github.com/flipboxfactory/craft-link) fields.
 - Events to write your own link types, or extend existing ones.
 
 ## Link Types


### PR DESCRIPTION
Although the name of Typed Link Field is inconsistent between their repository, documentation and code, I think "Typed Link Field" makes more sense here than "Typed Link", and it does show as "Typed link field" if you install it on a site.