### PR TITLE
Add `embedDetectorsSettings` to pass to embed settings

### DIFF
--- a/docs/get-started/configuration.md
+++ b/docs/get-started/configuration.md
@@ -10,6 +10,7 @@ return [
     '*' => [
         'embedClientSettings' => [],
         'embedHeaders' => [],
+        'embedDetectorsSettings' => [],
     ],
 ];
 ```
@@ -17,6 +18,7 @@ return [
 ## Configuration options
 - `embedClientSettings` - Define any [settings](https://github.com/oscarotero/Embed#settings) to pass to the Curl Client for Embed links.
 - `embedHeaders` - Define any [headers](https://github.com/oscarotero/Embed#settings) to pass to the Curl Client for Embed links.
+- `embedDetectorsSettings` - Define any [settings](https://github.com/oscarotero/Embed#settings) to pass to the detectors for Embed links.
 
 ## Control Panel
 You can also manage configuration settings through the Control Panel by visiting Settings → Hyper.

--- a/src/links/Embed.php
+++ b/src/links/Embed.php
@@ -55,6 +55,8 @@ class Embed extends Link
                 $crawler->addDefaultHeaders($settings->embedHeaders);
 
                 $embed = new \Embed\Embed($crawler);
+                $embed->setSettings($settings->embedDetectorsSettings);
+
                 $info = $embed->get($url);
 
                 $values['linkValue'] = Json::decode(Json::encode([

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -10,5 +10,6 @@ class Settings extends Model
 
     public array $embedClientSettings = [];
     public array $embedHeaders = [];
+    public array $embedDetectorsSettings = [];
 
 }


### PR DESCRIPTION
Useful for adding additional settings to embed providers. E.g. additional query parameters to a vimeo or youtube like 'autoplay' or 'responsive'