### PR TITLE
Apply default new window setting for multiple links version

### DIFF
--- a/src/web/assets/field/src/js/components/HyperInput.vue
+++ b/src/web/assets/field/src/js/components/HyperInput.vue
@@ -274,6 +274,11 @@ export default {
                 handle,
             };
 
+            // Apply default new window setting
+            if (this.settings.newWindow) {
+                newLink.newWindow = this.settings.defaultNewWindow ?? false;
+            }
+
             // Add it to the link collection
             this.proxyValue.push(newLink);
 


### PR DESCRIPTION
When using the multiple links version of the field, the default new window setting was not applied to newly added links.
This fixes that :)