### PR TITLE
Check if cache element has an id

### DIFF
--- a/src/Hyper.php
+++ b/src/Hyper.php
@@ -207,7 +207,7 @@ class Hyper extends Plugin
                     return;
                 }
 
-                if (Craft::$app->getResponse()->getIsOk()) {
+                if (Craft::$app->getResponse()->getIsOk() && $event->element->id) {
                     Hyper::$plugin->getElementCache()->addToRenderCache($event->element->id, $event->element->siteId);
                 }
             });


### PR DESCRIPTION
Prevents errors i've been getting:

```
TypeError
verbb\hyper\services\ElementCache::addToRenderCache(): Argument #1 ($elementId) must be of type int, null given, called in /app/vendor/verbb/hyper/src/Hyper.php on line 211
```