### PR TITLE
prevent url to get emojies

### DIFF
--- a/src/fields/HyperField.php
+++ b/src/fields/HyperField.php
@@ -820,7 +820,9 @@ class HyperField extends Field
                 $value = self::_decodeStringValues($value);
             } else if (is_string($value)) {
                 // TODO: replace in Craft 4.4+ or LitEmoji 5+
-                $value = StringHelper::shortcodesToEmoji($value);
+                if ($key !== 'linkValue') {
+                    $value = StringHelper::shortcodesToEmoji($value);
+                }
             }
 
             $values[$key] = $value;


### PR DESCRIPTION
If your url has string parts like :v: or :b:, the method transform them to an emoji.

The fix prevent this change.