### PR TITLE
Use Craft's internal cache of field layouts

### DIFF
--- a/src/base/Link.php
+++ b/src/base/Link.php
@@ -205,7 +205,7 @@ abstract class Link extends Element implements LinkInterface
     public function defineRules(): array
     {
         $rules = parent::defineRules();
-            
+
         // Validation for only when saving Hyper fields and their settings
         $rules[] = [['label', 'handle'], 'required', 'on' => [self::SCENARIO_SETTINGS]];
 
@@ -313,7 +313,17 @@ abstract class Link extends Element implements LinkInterface
         }
 
         if ($this->layoutUid) {
-            $this->_fieldLayout = Hyper::$plugin->getService()->getFieldLayoutByUid($this->layoutUid);
+            $fieldLayout = null;
+            $layouts = Craft::$app->getFields()->getLayoutsByType(static::class);
+
+            foreach ($layouts as $layout) {
+                if ($layout->uid === $this->layoutUid) {
+                    $fieldLayout = $layout;
+                    break;
+                }
+            }
+
+            $this->_fieldLayout = $fieldLayout;
         }
 
         return $this->_fieldLayout;


### PR DESCRIPTION
I noticed you did this for the Craft 5 branch already. We're having performance issues with GQL where the schema generation fires off a query for every field layout for every link type for every Hyper Field. That means my CTA field triggers a DB query for CTA Phone, CTA Url, CTA Email, CTA etc… link types.

This uses Craft's Field service's `::getLayoutsByType` for the link type and then filters down by the UID. Craft 4 doesn't expose get layout by UID so we have to do this. Internally Craft is already eager loading and caching field layouts so this does not fire off as many database queries.

I left the old Hyper `::getFieldLayoutByUid()` method because it's used by the field layout designer which doesn't have a proper context. We only know the UID not if it's a phone or URL link type so `::getLayoutsByType()` wouldn't work there.